### PR TITLE
add vote for adding docker-images repo

### DIFF
--- a/votes/2024-05-30-add-docker-images-repo.md
+++ b/votes/2024-05-30-add-docker-images-repo.md
@@ -1,0 +1,38 @@
+# 申请创建 docker-images 项目
+
+## 项目基本信息
+
+项目名称：docker-images
+
+项目目的：存放 OceanBase 组织内产品的 Docker 镜像相关的文件，并借助 GitHub Workflow 发布镜像到 Docker Hub。
+
+项目责任人(github id)：
+- PMC：whhe
+- PMC：Linxiansheng
+- committer：chris-sun-star
+- committer：powerfool
+
+开源协议：Apache 2.0
+
+## 开源项目检查清单
+
+> 检查清单是为了让项目更规范，让社区用户更容易使用。应该在项目创建后，尽快补充清单中的信息。
+
+（目前尚未创建单独仓库，会在初始 pull request 或 commit 中包含以下勾选内容）
+
+- [x] 包含 README.md
+- [x] 工程类项目需要包含 CONTRIBUTING.md。参考 OceanBase 社区 [CONTRIBUTING 文件](https://github.com/oceanbase/.github/blob/main/CONTRIBUTING.md)
+- [] 包含文件 CODE_OF_CONDUCT.md （没有此文件将使用社区现有的[行为准则文件](https://github.com/oceanbase/.github/blob/main/CODE_OF_CONDUCT.md) ）
+- [] 工程类项目包含用户安装指导说明（通常在README.md中说明）
+- [] 工程类项目包含用户使用指导说明（通常在README.md中说明）
+- [] 工程类项目代码类项目包含编译指导说明（通常在README.md中说明）
+
+## 投票截止时间
+
+如果不满足投票条件，此投票将在 2024 年 6 月 6 日截止。
+
+> 满足投票条件是说投票已经成功，比如已经有不少于 2/3 的 TOC 投票，或者投票失败，比如有一半的 TOC 反对。
+
+## 投票结果
+
+参考 [申请创建 docker-images 项目](https://github.com/oceanbase/community/pull/8)。


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->

I'd like to start a vote for adding docker-images repo, just like https://github.com/oracle/docker-images.

## Solution Description
<!-- Please clearly and concisely describe your solution. -->

We can move the existing docker files in https://github.com/oceanbase/oceanbase/tree/6797c56e2ff2f0dfb0fceec206822a46b494fbea/tools/docker/standalone to the new repo, and gradually add missing images such as oblogproxy and obproxy in the future.