### PR TITLE
add vote for adding nextstack-club repo

### DIFF
--- a/votes/2024-10-17-add-nextstack-club-repo.md
+++ b/votes/2024-10-17-add-nextstack-club-repo.md
@@ -1,0 +1,31 @@
+# 申请创建 OceanBase Next Stack 应用代码仓库
+
+## 项目基本信息
+
+项目名称: nextstack-club
+
+项目目的: OceanBase与几家合作伙伴成立了Next Stack技术联盟，该项目存放用于展示该联盟的介绍信息的前端代码与静态资源
+
+项目责任人(github id):
+
+- PMC: foixes
+- Committer: yuanfang19959
+
+开源协议：Apache 2.0
+
+## 开源项目检查清单
+
+- [x] 包含 README.md
+- [x] 工程类项目需要包含 CONTRIBUTING.md。参考 OceanBase 社区 [CONTRIBUTING 文件](https://github.com/oceanbase/.github/blob/main/CONTRIBUTING.md)
+- [x] 包含文件 CODE_OF_CONDUCT.md （没有此文件将使用社区现有的[行为准则文件](https://github.com/oceanbase/.github/blob/main/CODE_OF_CONDUCT.md) ）
+- [x] 工程类项目包含用户安装指导说明（通常在 README.md 中说明）
+- [x] 工程类项目包含用户使用指导说明（通常在 README.md 中说明）
+- [x] 工程类项目代码类项目包含编译指导说明（通常在 README.md 中说明）
+
+## 投票截止时间
+
+如果不满足投票条件，此投票将在 2024 年 10 月 23 日截止
+
+## 投票结果
+
+参考 [申请创建 OceanBase Next Stack 项目](https://github.com/oceanbase/community/pull/19)


### PR DESCRIPTION
## Summary
nextstack-club 用于存放Next Stack技术联盟网站的前端代码与静态资源，该技术联盟是由OceanBase与几家合作伙伴成立的。

